### PR TITLE
feat: search for Dockerfile var in any tf file within dir/subdirs

### DIFF
--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -66,7 +66,7 @@ if any(missing_vars.values()):
     logging.error("Missing environment variables in the Terraform files:")
     for var, dirs in missing_vars.items():
         if dirs:
-            logging.error(f"Variable '{var}' is missing in directories: {', '.join(dirs)}\n")
+            logging.error(f"Variable '{var}' is missing in: {', '.join(dirs)}\n")
     sys.exit(1)
 else:
     logging.info("All variables defined in Dockerfile have been used in deployment or are exempted.")

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -46,8 +46,9 @@ for root, dirs, files in os.walk(terraform_dir):
                 content = tf_file_content.read()
 
             # Extract variable names from .tf file
-            matched_groups = re.findall(r'variable\s+"([^"]+)"', content)
-            variable_names = [name for group in matched_groups for name in group if name is not None]
+            #matched_groups = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+"(\w+)"|"(\w+)"', content)
+            #variable_names = [name for group in matched_groups for name in group if name is not None]
+            variable_names = re.findall(r'=\s+"(\w+)"', content)
 
             # Determine excluded variables for this directory
             current_except_vars = except_vars

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -56,7 +56,10 @@ for root, dirs, files in os.walk(terraform_dir):
             # Check if each variable is used or missing in the .tf file
             for var in missing_vars.keys():
                 if var not in variable_names and var not in current_except_vars:
-                    missing_vars[var].append(tf_file_path)
+                    # Get relative subdirectory path
+                    rel_subdir = os.path.relpath(root, terraform_dir)
+                    if rel_subdir not in missing_vars[var]:
+                        missing_vars[var].append(rel_subdir)
 
         except FileNotFoundError:
             pass
@@ -66,7 +69,7 @@ if any(missing_vars.values()):
     logging.error("Missing environment variables in the Terraform files:")
     for var, dirs in missing_vars.items():
         if dirs:
-            logging.error(f"Variable '{var}' is missing in: {', '.join(dirs)}\n")
+            logging.error(f"Variable '{var}' is missing in directories: {', '.join(dirs)}\n")
     sys.exit(1)
 else:
     logging.info("All variables defined in Dockerfile have been used in deployment or are exempted.")

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -45,11 +45,6 @@ for root, dirs, files in os.walk(terraform_dir):
             with open(tf_file_path, "r") as tf_file_content:
                 content = tf_file_content.read()
 
-            # Extract variable names from .tf file
-            #matched_groups = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+"(\w+)"|"(\w+)"', content)
-            #variable_names = [name for group in matched_groups for name in group if name is not None]
-            variable_names = re.findall(r'\b' + re.escape(var) + r'\b', content)
-
             # Determine excluded variables for this directory
             current_except_vars = except_vars
             if root in dir_specific_except_vars:
@@ -57,7 +52,7 @@ for root, dirs, files in os.walk(terraform_dir):
 
             # Check if each variable is used or missing in the .tf file
             for var in missing_vars.keys():
-                if var not in variable_names and var not in current_except_vars:
+                if re.search(r'\b' + re.escape(var) + r'\b', content) is None and var not in current_except_vars:
                     # Get relative subdirectory path
                     rel_subdir = os.path.relpath(root, terraform_dir)
                     if rel_subdir not in missing_vars[var]:

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -46,7 +46,7 @@ for root, dirs, files in os.walk(terraform_dir):
                 content = tf_file_content.read()
 
             # Extract variable names from .tf file
-            matched_groups = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+"(\w+)"|"(\w+)"', content)
+            matched_groups = re.findall(r'variable\s+"([^"]+)"', content)
             variable_names = [name for group in matched_groups for name in group if name is not None]
 
             # Determine excluded variables for this directory

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -52,7 +52,7 @@ for root, dirs, files in os.walk(terraform_dir):
 
             # Check if each variable is used or missing in the .tf file
             for var in missing_vars.keys():
-                if var not in current_except_vars and re.search(r'\b' + re.escape(var) + r'\b', content) is None:
+                if var not in current_except_vars and not re.findall(r'"\s*{}\s*"'.format(var), content):
                     # Get relative subdirectory path
                     rel_subdir = os.path.relpath(root, terraform_dir)
                     if rel_subdir not in missing_vars[var]:

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -46,7 +46,7 @@ for root, dirs, files in os.walk(terraform_dir):
                 content = tf_file_content.read()
 
             # Extract variable names from .tf file
-            variable_names = re.findall(r'=\s+"(\w+)"', content)
+            variable_names = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+\'(\w+)\'', content)
 
             # Determine excluded variables for this directory
             current_except_vars = except_vars

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -46,7 +46,8 @@ for root, dirs, files in os.walk(terraform_dir):
                 content = tf_file_content.read()
 
             # Extract variable names from .tf file
-            variable_names = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+\'(\w+)\'', content)
+            matched_groups = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+\'(\w+)\'', content)
+            variable_names = [name for group in matched_groups for name in group if name is not None]
 
             # Determine excluded variables for this directory
             current_except_vars = except_vars

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -52,7 +52,7 @@ for root, dirs, files in os.walk(terraform_dir):
 
             # Check if each variable is used or missing in the .tf file
             for var in missing_vars.keys():
-                if re.search(r'\b' + re.escape(var) + r'\b', content) is None and var not in current_except_vars:
+                if var not in current_except_vars and re.search(r'\b' + re.escape(var) + r'\b', content) is None:
                     # Get relative subdirectory path
                     rel_subdir = os.path.relpath(root, terraform_dir)
                     if rel_subdir not in missing_vars[var]:

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -48,7 +48,7 @@ for root, dirs, files in os.walk(terraform_dir):
             # Extract variable names from .tf file
             #matched_groups = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+"(\w+)"|"(\w+)"', content)
             #variable_names = [name for group in matched_groups for name in group if name is not None]
-            variable_names = re.findall(r'=\s+"(\w+)"', content)
+            variable_names = re.findall(r'\b' + re.escape(var) + r'\b', content)
 
             # Determine excluded variables for this directory
             current_except_vars = except_vars

--- a/scripts/docker-terraform-vars/variables_validate.py
+++ b/scripts/docker-terraform-vars/variables_validate.py
@@ -46,7 +46,7 @@ for root, dirs, files in os.walk(terraform_dir):
                 content = tf_file_content.read()
 
             # Extract variable names from .tf file
-            matched_groups = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+\'(\w+)\'', content)
+            matched_groups = re.findall(r'name\s+=\s+"(\w+)"|\s+=\s+"(\w+)"|"(\w+)"', content)
             variable_names = [name for group in matched_groups for name in group if name is not None]
 
             # Determine excluded variables for this directory


### PR DESCRIPTION
This PR was created to add flexibility of the script to search for variable names in any tf files within the specified terraform directory and its subdirectories. If a variable is found in any tf file, the variable will not be flagged as missing.

If variable is missing in any of the files, it will be flagged as missing in the directory/subdirectory